### PR TITLE
feat: add relay_state in permission set

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module "idc" {
     management       = var.management_account_id
     audit            = var.audit_account_id
     session_duration = "8"
-    relay_state      = "https://s3.console.aws.amazon.com/s3/home?region=us-east-1#"
+    relay_state      = "https://eu-west-3.console.aws.amazon.com"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ module "idc" {
     management       = var.management_account_id
     audit            = var.audit_account_id
     session_duration = "8"
+    relay_state      = "https://s3.console.aws.amazon.com/s3/home?region=us-east-1#"
   }
 }
 ```

--- a/examples/permission_sets.yml
+++ b/examples/permission_sets.yml
@@ -4,6 +4,7 @@
 Admin: #permission set name
   description: null
   tags: null
+  relay_state: null
   session_duration: "PT8H"
   inline_policy: null
   aws_managed_policies:
@@ -13,6 +14,7 @@ Admin: #permission set name
 ReadOnly:
   description: "Read-only role, check policy for exact details"
   tags: null
+  relay_state: null
   session_duration: null
   inline_policy: "ReadOnly"
   aws_managed_policies: null
@@ -22,6 +24,7 @@ ReadOnly:
 SecurityAdmin:
   description: "Security admin role"
   tags: null
+  relay_state: null
   session_duration: null
   inline_policy: null
   aws_managed_policies: null

--- a/examples/permission_sets.yml
+++ b/examples/permission_sets.yml
@@ -24,7 +24,7 @@ ReadOnly:
 SecurityAdmin:
   description: "Security admin role"
   tags: null
-  relay_state: null
+  relay_state: "https://eu-west-2.console.aws.amazon.com/securityhub/"
   session_duration: null
   inline_policy: null
   aws_managed_policies: null

--- a/examples/permission_sets.yml.tpl
+++ b/examples/permission_sets.yml.tpl
@@ -4,7 +4,7 @@
 Admin: 
   description: null
   tags: null
-  relay_state: null
+  relay_state: ${relay_state}
   session_duration: "PT${session_duration}H"
   inline_policy: null
   aws_managed_policies:

--- a/examples/permission_sets.yml.tpl
+++ b/examples/permission_sets.yml.tpl
@@ -4,6 +4,7 @@
 Admin: 
   description: null
   tags: null
+  relay_state: null
   session_duration: "PT${session_duration}H"
   inline_policy: null
   aws_managed_policies:

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ resource "aws_ssoadmin_permission_set" "this" {
   description      = each.value.description
   instance_arn     = tolist(data.aws_ssoadmin_instances.this.arns)[0]
   tags             = each.value.tags
+  relay_state      = each.value.relay_state
   session_duration = each.value.session_duration
 
   lifecycle {


### PR DESCRIPTION

*Description of changes:*

Add [relay_state](https://registry.terraform.io/providers/hashicorp/awS/6.44.0/docs/resources/ssoadmin_permission_set#relay_state-3) argument to the module

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
