### PR TITLE
fix: handle case where `relay_state` is not present

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "aws_ssoadmin_permission_set" "this" {
   description      = each.value.description
   instance_arn     = tolist(data.aws_ssoadmin_instances.this.arns)[0]
   tags             = each.value.tags
-  relay_state      = each.value.relay_state
+  relay_state      = try(each.value.relay_state, null)
   session_duration = each.value.session_duration
 
   lifecycle {


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* 2c257705fc80d309cc0c322ccf80b17620a8133a constituted a breaking change because it made `relay_state` a mandatory property of users' YAML data. We can avoid that breaking change by handling the case where `relay_state` is not present.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
