### PR TITLE
fix: destroy assignments before policies to avoid race condition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,5 +61,12 @@ module "account_assignment" {
   account_assignment  = each.value.account_list
   instances_arns      = tolist(data.aws_ssoadmin_instances.this.arns)[0]
   identity_store_id   = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+
+  depends_on = [
+    aws_ssoadmin_permission_set_inline_policy.this,
+    module.aws_managed_policies,
+    module.customer-managed_policies,
+    module.aws_permissions_boundary,
+  ]
 }
 


### PR DESCRIPTION
When a permission set is removed or replaced (e.g. renamed) while it has an active account assignment, terraform apply intermittently fails with:
```
Error: waiting for SSO Permission Set (arn:aws:sso:::permissionSet/...) provision: unexpected state 'FAILED', wanted target 'SUCCEEDED'.
last error: Received a 404 status error: Assignment not found.
```
Re-running the apply succeeds.

The fix is to add a depends_on from module.account_assignment to the policy resources/modules (inline, AWS-managed, customer-managed, and permissions boundary) so that assignments are always destroyed before the policies attached to their permission sets.

